### PR TITLE
Change `async` argument variable name to not be a Python keyword

### DIFF
--- a/client/argparser.py
+++ b/client/argparser.py
@@ -427,7 +427,7 @@ def createParser(config):
                         help="Show version of the API client software.")
     parser.add_argument("-d", "--debug", action="count", dest="debug_level",
                         help="Increase level of debugging output.")
-    parser.add_argument("-a", "--async", action="store_true", dest="async",
+    parser.add_argument("-a", "--async", action="store_true", dest="async_nowait",
                         help="Do not wait for asynchronous operations to finish.")
     parser.add_argument("-u", "--user", action="store", dest="user", default=user,
                         help="User name for authentication.")

--- a/client/resource.py
+++ b/client/resource.py
@@ -307,7 +307,7 @@ def _processResponse(session, resource, response, schema, cache, data):
 
     ### Success, handle result.
 
-    if status == 202 and not session.arguments().async:
+    if status == 202 and not session.arguments().async_nowait:
         # Print the response string for information.
         msg = _responseString(resource, status, None)
 


### PR DESCRIPTION
As of late, `async` is now a keyword in Python 3.7, and as such the argument variable being named this caused a syntax error when using a new version of the Python interpreter. This simply changes the name to be `async_nowait` which resolves the issue.

References:

* https://bugs.python.org/issue30406
* https://github.com/pycontribs/jira/issues/603 (Example: other occurance of this issue)
* https://github.com/ansible/ansible/issues/42105 (Example: other occurance of this issue)