### PR TITLE
Treat KeyboardInterrupt exception as != YES

### DIFF
--- a/client/resource.py
+++ b/client/resource.py
@@ -335,14 +335,16 @@ def _processResponse(session, resource, response, schema, cache, data):
             print()
             print("== To proceed, enter 'YES': ", end="")
             sys.stdout.flush()
+            try:
+                if sys.stdin.readline() != "YES\n":
+                    print("== Aborted")
+                    return
 
-            if sys.stdin.readline() != "YES\n":
-                print("== Aborted")
+                print("== Confirmed, proceeding")
+                print()
+            except KeyboardInterrupt:
+                print("\n== Aborted")
                 return
-
-            print("== Confirmed, proceeding")
-            print()
-
         # Reissue the request with the URL we got.
         return process(session, resource, url)
 


### PR DESCRIPTION
It looks like right now when a confirmation is interrupted via `CTRL-C`, it results in a crash that looks like the following, as a result of not handling a KeyboardInterrupt exception raised by `readline`.

```
$ corelight-client smartpcap storage shutdown

== Confirmation required ==

This will shutdown Smart PCAP external storage, which requires sensor reboot to resume the capture function.

== To proceed, enter 'YES': ^CTraceback (most recent call last):
  File "/usr/bin/corelight-client", line 197, in <module>
    client.resource.process(session, resource)
  File "/usr/local/python38/lib/python3.8/site-packages/client/resource.py", line 250, in process
    _processResponse(session, resource, response, schema, cache, data)
  File "/usr/local/python38/lib/python3.8/site-packages/client/resource.py", line 334, in _processResponse
    if sys.stdin.readline() != "YES\n":
KeyboardInterrupt
```

With this change it feels a bit more pleasant:
```
$ corelight-client smartpcap storage shutdown

== Confirmation required ==

This will shutdown Smart PCAP external storage, which requires sensor reboot to resume the capture function.

== To proceed, enter 'YES': ^C
== Aborted
```